### PR TITLE
Enhancement(Slider): Different slider sizes for single and range sliders

### DIFF
--- a/src/components/Slider/RangeSlider.tsx
+++ b/src/components/Slider/RangeSlider.tsx
@@ -8,6 +8,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
   min = 0,
   max = 100,
   step = 1,
+  size = "medium",
   value: controlledValue,
   defaultValue = [20, 80],
   onChange,
@@ -95,21 +96,53 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
     [disabled, min, max, low, high, updateValue],
   );
 
+  // Get size-specific CSS classes
+  const getSizeClasses = () => {
+    const sizeClassMap = {
+      small: {
+        slider: styles.sliderSmall,
+        track: styles.trackSmall,
+        filled: styles.filledSmall,
+        thumb: styles.thumbSmall,
+      },
+      medium: {
+        slider: styles.sliderMedium,
+        track: styles.trackMedium,
+        filled: styles.filledMedium,
+        thumb: styles.thumbMedium,
+      },
+      large: {
+        slider: styles.sliderLarge,
+        track: styles.trackLarge,
+        filled: styles.filledLarge,
+        thumb: styles.thumbLarge,
+      },
+    };
+    return sizeClassMap[size];
+  };
+
+  const sizeClasses = getSizeClasses();
+
   return (
     <div
       ref={trackRef}
-      className={[styles.slider, disabled && styles.disabled, className]
+      className={[
+        styles.slider,
+        sizeClasses.slider,
+        disabled && styles.disabled,
+        className,
+      ]
         .filter(Boolean)
         .join(" ")}
       onMouseDown={handleTrackClick}
       onTouchStart={handleTrackClick}
     >
       {/* Track */}
-      <div className={styles.track} />
+      <div className={`${styles.track} ${sizeClasses.track}`} />
 
       {/* Filled range */}
       <div
-        className={styles.filled}
+        className={`${styles.filled} ${sizeClasses.filled}`}
         style={{
           left: `${lowPercent}%`,
           width: `${highPercent - lowPercent}%`,
@@ -118,7 +151,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
 
       {/* Low Thumb */}
       <div
-        className={styles.thumb}
+        className={`${styles.thumb} ${sizeClasses.thumb}`}
         style={{ left: `${lowPercent}%` }}
         tabIndex={disabled ? -1 : 0}
         role="slider"
@@ -142,7 +175,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
 
       {/* High Thumb */}
       <div
-        className={styles.thumb}
+        className={`${styles.thumb} ${sizeClasses.thumb}`}
         style={{ left: `${highPercent}%` }}
         tabIndex={disabled ? -1 : 0}
         role="slider"

--- a/src/components/Slider/RangeSlider.tsx
+++ b/src/components/Slider/RangeSlider.tsx
@@ -3,6 +3,7 @@ import { RangeSliderProps } from "./Slider.types";
 import { useSlider } from "./hooks/useSlider";
 import { valueToPercent } from "./utils/math";
 import styles from "./styles.module.scss";
+import { useSliderSizeClasses } from "./hooks/useSliderSizeClasses";
 
 const RangeSlider: React.FC<RangeSliderProps> = ({
   min = 0,
@@ -25,6 +26,8 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
     controlledValue,
     onChange,
   });
+
+  const sizeClasses = useSliderSizeClasses(styles, size);
 
   const [low, high] = value;
 
@@ -95,33 +98,6 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
     },
     [disabled, min, max, low, high, updateValue],
   );
-
-  // Get size-specific CSS classes
-  const getSizeClasses = () => {
-    const sizeClassMap = {
-      small: {
-        slider: styles.sliderSmall,
-        track: styles.trackSmall,
-        filled: styles.filledSmall,
-        thumb: styles.thumbSmall,
-      },
-      medium: {
-        slider: styles.sliderMedium,
-        track: styles.trackMedium,
-        filled: styles.filledMedium,
-        thumb: styles.thumbMedium,
-      },
-      large: {
-        slider: styles.sliderLarge,
-        track: styles.trackLarge,
-        filled: styles.filledLarge,
-        thumb: styles.thumbLarge,
-      },
-    };
-    return sizeClassMap[size];
-  };
-
-  const sizeClasses = getSizeClasses();
 
   return (
     <div

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -8,6 +8,7 @@ const Slider: React.FC<SingleValueSliderProps> = ({
   min = 0,
   max = 100,
   step = 1,
+  size = "medium",
   value: controlledValue,
   defaultValue = 0,
   onChange,
@@ -63,24 +64,59 @@ const Slider: React.FC<SingleValueSliderProps> = ({
 
   const percent = valueToPercent(value, min, max);
 
+  // Get size-specific CSS classes
+  const getSizeClasses = () => {
+    const sizeClassMap = {
+      small: {
+        slider: styles.sliderSmall,
+        track: styles.trackSmall,
+        filled: styles.filledSmall,
+        thumb: styles.thumbSmall,
+      },
+      medium: {
+        slider: styles.sliderMedium,
+        track: styles.trackMedium,
+        filled: styles.filledMedium,
+        thumb: styles.thumbMedium,
+      },
+      large: {
+        slider: styles.sliderLarge,
+        track: styles.trackLarge,
+        filled: styles.filledLarge,
+        thumb: styles.thumbLarge,
+      },
+    };
+    return sizeClassMap[size];
+  };
+
+  const sizeClasses = getSizeClasses();
+
   return (
     <div
       ref={trackRef}
-      className={[styles.slider, disabled && styles.disabled, className]
+      className={[
+        styles.slider,
+        sizeClasses.slider,
+        disabled && styles.disabled,
+        className,
+      ]
         .filter(Boolean)
         .join(" ")}
       onMouseDown={handlePointerDown}
       onTouchStart={handlePointerDown}
     >
       {/* Track */}
-      <div className={styles.track} />
+      <div className={`${styles.track} ${sizeClasses.track}`} />
 
       {/* Filled Track */}
-      <div className={styles.filled} style={{ width: `${percent}%` }} />
+      <div
+        className={`${styles.filled} ${sizeClasses.filled}`}
+        style={{ width: `${percent}%` }}
+      />
 
       {/* Thumb */}
       <div
-        className={styles.thumb}
+        className={`${styles.thumb} ${sizeClasses.thumb}`}
         style={{ left: `${percent}%` }}
         tabIndex={disabled ? -1 : 0}
         role="slider"

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -3,6 +3,7 @@ import { SingleValueSliderProps } from "./Slider.types";
 import { useSlider } from "./hooks/useSlider";
 import { valueToPercent } from "./utils/math";
 import styles from "./styles.module.scss";
+import { useSliderSizeClasses } from "./hooks/useSliderSizeClasses";
 
 const Slider: React.FC<SingleValueSliderProps> = ({
   min = 0,
@@ -25,6 +26,8 @@ const Slider: React.FC<SingleValueSliderProps> = ({
     controlledValue,
     onChange,
   });
+
+  const sizeClasses = useSliderSizeClasses(styles, size);
 
   // Map mouse position to slider value
   const handlePointerMove = useCallback(
@@ -63,33 +66,6 @@ const Slider: React.FC<SingleValueSliderProps> = ({
   );
 
   const percent = valueToPercent(value, min, max);
-
-  // Get size-specific CSS classes
-  const getSizeClasses = () => {
-    const sizeClassMap = {
-      small: {
-        slider: styles.sliderSmall,
-        track: styles.trackSmall,
-        filled: styles.filledSmall,
-        thumb: styles.thumbSmall,
-      },
-      medium: {
-        slider: styles.sliderMedium,
-        track: styles.trackMedium,
-        filled: styles.filledMedium,
-        thumb: styles.thumbMedium,
-      },
-      large: {
-        slider: styles.sliderLarge,
-        track: styles.trackLarge,
-        filled: styles.filledLarge,
-        thumb: styles.thumbLarge,
-      },
-    };
-    return sizeClassMap[size];
-  };
-
-  const sizeClasses = getSizeClasses();
 
   return (
     <div

--- a/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
+++ b/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
@@ -1,0 +1,216 @@
+import { renderHook } from "@testing-library/react";
+import { useSliderSizeClasses } from "../useSliderSizeClasses";
+
+// Mock styles object that mimics CSS modules
+const mockStyles = {
+  sliderSmall: "slider-small-class",
+  sliderMedium: "slider-medium-class",
+  sliderLarge: "slider-large-class",
+  trackSmall: "track-small-class",
+  trackMedium: "track-medium-class",
+  trackLarge: "track-large-class",
+  filledSmall: "filled-small-class",
+  filledMedium: "filled-medium-class",
+  filledLarge: "filled-large-class",
+  thumbSmall: "thumb-small-class",
+  thumbMedium: "thumb-medium-class",
+  thumbLarge: "thumb-large-class",
+};
+
+describe("useSliderSizeClasses", () => {
+  describe("size class mapping", () => {
+    it("should return correct classes for small size", () => {
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(mockStyles, "small"),
+      );
+
+      expect(result.current).toEqual({
+        slider: "slider-small-class",
+        track: "track-small-class",
+        filled: "filled-small-class",
+        thumb: "thumb-small-class",
+      });
+    });
+
+    it("should return correct classes for medium size", () => {
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(mockStyles, "medium"),
+      );
+
+      expect(result.current).toEqual({
+        slider: "slider-medium-class",
+        track: "track-medium-class",
+        filled: "filled-medium-class",
+        thumb: "thumb-medium-class",
+      });
+    });
+
+    it("should return correct classes for large size", () => {
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(mockStyles, "large"),
+      );
+
+      expect(result.current).toEqual({
+        slider: "slider-large-class",
+        track: "track-large-class",
+        filled: "filled-large-class",
+        thumb: "thumb-large-class",
+      });
+    });
+  });
+
+  describe("memoization behavior", () => {
+    it("should return the same object reference when size doesn't change", () => {
+      const { result, rerender } = renderHook(
+        ({ size }: { size: "small" | "medium" | "large" }) =>
+          useSliderSizeClasses(mockStyles, size),
+        { initialProps: { size: "medium" as const } },
+      );
+
+      const firstResult = result.current;
+
+      // Rerender with same size
+      rerender({ size: "medium" });
+
+      expect(result.current).toBe(firstResult);
+    });
+
+    it("should return different object reference when size changes", () => {
+      const { result, rerender } = renderHook(
+        ({ size }: { size: "small" | "medium" | "large" }) =>
+          useSliderSizeClasses(mockStyles, size),
+        { initialProps: { size: "medium" as const } },
+      );
+
+      const firstResult = result.current;
+
+      // Rerender with different size
+      rerender({ size: "large" });
+
+      expect(result.current).not.toBe(firstResult);
+      expect(result.current).toEqual({
+        slider: "slider-large-class",
+        track: "track-large-class",
+        filled: "filled-large-class",
+        thumb: "thumb-large-class",
+      });
+    });
+
+    it("should return same object reference when styles object changes but size stays same", () => {
+      const { result, rerender } = renderHook(
+        ({
+          styles,
+          size,
+        }: {
+          styles: Record<string, string>;
+          size: "small" | "medium" | "large";
+        }) => useSliderSizeClasses(styles, size),
+        {
+          initialProps: {
+            styles: mockStyles,
+            size: "medium" as const,
+          },
+        },
+      );
+
+      const firstResult = result.current;
+
+      // Rerender with new styles object but same size
+      const newStyles = { ...mockStyles };
+      rerender({ styles: newStyles, size: "medium" });
+
+      // Should still be the same result since useMemo only depends on size
+      expect(result.current).toBe(firstResult);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle missing style classes gracefully", () => {
+      const incompleteStyles = {
+        sliderSmall: "slider-small-class",
+        // Missing other classes
+      };
+
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(incompleteStyles, "small"),
+      );
+
+      expect(result.current).toEqual({
+        slider: "slider-small-class",
+        track: undefined,
+        filled: undefined,
+        thumb: undefined,
+      });
+    });
+
+    it("should handle empty styles object", () => {
+      const emptyStyles = {};
+
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(emptyStyles, "medium"),
+      );
+
+      expect(result.current).toEqual({
+        slider: undefined,
+        track: undefined,
+        filled: undefined,
+        thumb: undefined,
+      });
+    });
+  });
+
+  describe("type safety", () => {
+    it("should work with different styles object shapes", () => {
+      const customStyles = {
+        sliderSmall: "custom-slider-sm",
+        sliderMedium: "custom-slider-md",
+        sliderLarge: "custom-slider-lg",
+        trackSmall: "custom-track-sm",
+        trackMedium: "custom-track-md",
+        trackLarge: "custom-track-lg",
+        filledSmall: "custom-filled-sm",
+        filledMedium: "custom-filled-md",
+        filledLarge: "custom-filled-lg",
+        thumbSmall: "custom-thumb-sm",
+        thumbMedium: "custom-thumb-md",
+        thumbLarge: "custom-thumb-lg",
+        // Additional properties should be ignored
+        someOtherClass: "ignored",
+      };
+
+      const { result } = renderHook(() =>
+        useSliderSizeClasses(customStyles, "large"),
+      );
+
+      expect(result.current).toEqual({
+        slider: "custom-slider-lg",
+        track: "custom-track-lg",
+        filled: "custom-filled-lg",
+        thumb: "custom-thumb-lg",
+      });
+    });
+  });
+
+  describe("performance", () => {
+    it("should not create new objects on every render when size is stable", () => {
+      const results: { [key: string]: string }[] = [];
+
+      const { rerender } = renderHook(() => {
+        const result = useSliderSizeClasses(mockStyles, "medium");
+        results.push(result);
+        return result;
+      });
+
+      // Trigger multiple rerenders
+      rerender();
+      rerender();
+      rerender();
+
+      // All results should be the same object reference
+      expect(results).toHaveLength(4); // Initial + 3 rerenders
+      expect(results[0]).toBe(results[1]);
+      expect(results[1]).toBe(results[2]);
+      expect(results[2]).toBe(results[3]);
+    });
+  });
+});

--- a/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
+++ b/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
@@ -149,8 +149,9 @@ describe("useSliderSizeClasses", () => {
       const newStyles = { ...mockStyles };
       rerender({ styles: newStyles, size: "medium" });
 
-      // Should still be the same result
-      expect(result.current).toStrictEqual(firstResult);
+      // Should be a different object reference, but contents should be equal
+      expect(result.current).not.toBe(firstResult);
+      expect(result.current).toEqual(firstResult);
     });
   });
 

--- a/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
+++ b/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
@@ -79,7 +79,7 @@ describe("useSliderSizeClasses", () => {
       const { result, rerender } = renderHook(
         ({ size }: { size: "small" | "medium" | "large" }) =>
           useSliderSizeClasses(mockStyles, size),
-        { initialProps: { size: "medium" as const } },
+        { initialProps: { size: "medium" } },
       );
 
       const firstResult = result.current;
@@ -96,7 +96,37 @@ describe("useSliderSizeClasses", () => {
       });
     });
 
-    it("should return same object reference when styles object changes but size stays same", () => {
+    it("should return different object reference when styles object changes but size stays same", () => {
+      const { result, rerender } = renderHook(
+        ({
+          styles,
+          size,
+        }: {
+          styles: Record<string, string>;
+          size: "small" | "medium" | "large";
+        }) => useSliderSizeClasses(styles, size),
+        {
+          initialProps: {
+            styles: mockStyles,
+            size: "medium" as const,
+          },
+        },
+      );
+
+      // Rerender with new styles object but same size
+      const newStyles = { ...mockStyles };
+      rerender({ styles: newStyles, size: "medium" });
+
+      // Should now return a new object since styles changed
+      expect(result.current).toEqual({
+        slider: "slider-medium-class",
+        track: "track-medium-class",
+        filled: "filled-medium-class",
+        thumb: "thumb-medium-class",
+      });
+    });
+
+    it("should return the same object reference when styles object and size stays same", () => {
       const { result, rerender } = renderHook(
         ({
           styles,
@@ -120,7 +150,7 @@ describe("useSliderSizeClasses", () => {
       rerender({ styles: newStyles, size: "medium" });
 
       // Should still be the same result since useMemo only depends on size
-      expect(result.current).toBe(firstResult);
+      expect(result.current).toStrictEqual(firstResult);
     });
   });
 

--- a/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
+++ b/src/components/Slider/hooks/__tests__/useSliderSizeClasses.test.ts
@@ -149,7 +149,7 @@ describe("useSliderSizeClasses", () => {
       const newStyles = { ...mockStyles };
       rerender({ styles: newStyles, size: "medium" });
 
-      // Should still be the same result since useMemo only depends on size
+      // Should still be the same result
       expect(result.current).toStrictEqual(firstResult);
     });
   });

--- a/src/components/Slider/hooks/useSliderSizeClasses.ts
+++ b/src/components/Slider/hooks/useSliderSizeClasses.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+
+const useSliderSizeClasses = (
+  styles: Record<string, string>,
+  size: "small" | "medium" | "large",
+) => {
+  const sizeClasses = useMemo(() => {
+    const sizeClassMap = {
+      small: {
+        slider: styles.sliderSmall,
+        track: styles.trackSmall,
+        filled: styles.filledSmall,
+        thumb: styles.thumbSmall,
+      },
+      medium: {
+        slider: styles.sliderMedium,
+        track: styles.trackMedium,
+        filled: styles.filledMedium,
+        thumb: styles.thumbMedium,
+      },
+      large: {
+        slider: styles.sliderLarge,
+        track: styles.trackLarge,
+        filled: styles.filledLarge,
+        thumb: styles.thumbLarge,
+      },
+    };
+    return sizeClassMap[size];
+  }, [size]);
+
+  return sizeClasses;
+};
+export { useSliderSizeClasses };

--- a/src/components/Slider/hooks/useSliderSizeClasses.ts
+++ b/src/components/Slider/hooks/useSliderSizeClasses.ts
@@ -26,7 +26,7 @@ const useSliderSizeClasses = (
       },
     };
     return sizeClassMap[size];
-  }, [size]);
+  }, [size, styles]);
 
   return sizeClasses;
 };

--- a/src/components/Slider/styles.module.scss
+++ b/src/components/Slider/styles.module.scss
@@ -2,10 +2,22 @@
   position: relative;
   width: var(--width-full);
   min-width: var(--width-200);
-  height: var(--space-6); /* 24px */
   cursor: pointer;
   display: flex;
   align-items: center;
+}
+
+/* Size variants */
+.sliderSmall {
+  height: var(--space-4); /* 16px */
+}
+
+.sliderMedium {
+  height: var(--space-6); /* 24px */
+}
+
+.sliderLarge {
+  height: var(--space-8); /* 32px */
 }
 
 .track {
@@ -13,10 +25,22 @@
   top: 50%;
   left: 0;
   transform: translateY(-50%);
-  height: var(--space-1, 6px); /* Fallback to 6px if space-1 is not defined */
   width: var(--width-full);
   background: var(--gray-200);
   border-radius: var(--radius-full);
+}
+
+/* Track size variants */
+.trackSmall {
+  height: 4px;
+}
+
+.trackMedium {
+  height: 6px;
+}
+
+.trackLarge {
+  height: 8px;
 }
 
 .filled {
@@ -24,19 +48,29 @@
   top: 50%;
   left: 0;
   transform: translateY(-50%);
-  height: var(--space-1, 6px);
   background: var(--color-primary);
   border-radius: var(--radius-full);
   pointer-events: none;
   z-index: var(--z-index-10);
 }
 
+/* Filled size variants */
+.filledSmall {
+  height: 4px;
+}
+
+.filledMedium {
+  height: 6px;
+}
+
+.filledLarge {
+  height: 8px;
+}
+
 .thumb {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: var(--width-20);
-  height: var(--width-20);
   background: var(--color-primary);
   border-radius: var(--radius-full);
   cursor: grab;
@@ -62,6 +96,22 @@
   &:focus-visible {
     box-shadow: 0 0 0 var(--space-1) var(--color-primary);
   }
+}
+
+/* Thumb size variants */
+.thumbSmall {
+  width: 16px;
+  height: 16px;
+}
+
+.thumbMedium {
+  width: var(--width-20);
+  height: var(--width-20);
+}
+
+.thumbLarge {
+  width: 24px;
+  height: 24px;
 }
 
 .disabled {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,3 @@
-@import "./_variables.scss";
-@import "./_mixins.scss";
-@import "./_utils.scss";
+@use "./_variables.scss";
+@use "./_mixins.scss";
+@use "./_utils.scss";

--- a/stories/RangeSlider.stories.tsx
+++ b/stories/RangeSlider.stories.tsx
@@ -22,6 +22,10 @@ const meta = {
     max: { control: "number" },
     step: { control: "number" },
     disabled: { control: "boolean" },
+    size: {
+      control: "select",
+      options: ["small", "medium", "large"],
+    },
   },
 } satisfies Meta<typeof RangeSlider>;
 
@@ -52,5 +56,26 @@ export const Disabled: Story = {
   args: {
     defaultValue: [40, 60],
     disabled: true,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    defaultValue: [20, 80],
+    size: "small",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    defaultValue: [20, 80],
+    size: "medium",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    defaultValue: [20, 80],
+    size: "large",
   },
 };

--- a/stories/Slider.stories.tsx
+++ b/stories/Slider.stories.tsx
@@ -22,6 +22,10 @@ const meta = {
     max: { control: "number" },
     step: { control: "number" },
     disabled: { control: "boolean" },
+    size: {
+      control: "select",
+      options: ["small", "medium", "large"],
+    },
   },
 } satisfies Meta<typeof Slider>;
 export default meta;
@@ -51,5 +55,26 @@ export const Disabled: Story = {
   args: {
     defaultValue: 50,
     disabled: true,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    defaultValue: 40,
+    size: "small",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    defaultValue: 40,
+    size: "medium",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    defaultValue: 40,
+    size: "large",
   },
 };


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for different slider sizes (small, medium, large) to both single and range sliders, replacing the previous fixed sizing approach with a flexible size system.

- Introduces a `size` prop with three variants: small, medium, and large
- Updates styling to use size-specific CSS classes for slider container, track, fill, and thumb elements
- Migrates from SCSS `@import` to `@use` syntax for better module management