### PR TITLE
moved style computation to utility, unit tests

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { ChipProps } from "./Chip.types";
 import { Button, BUTTON_SIZES, BUTTON_VARIANTS } from "@components/Button";
 import { Icon } from "@components/Icon";
+import { buildClassNames } from "@utils/classNames";
 import styles from "./styles.module.scss";
 
 const Chip: React.FC<ChipProps> = ({
@@ -10,7 +11,7 @@ const Chip: React.FC<ChipProps> = ({
   className,
   ariaLabel,
   style,
-  onClick,
+  onRemove,
   disabled,
   variant,
   interactive,
@@ -31,16 +32,20 @@ const Chip: React.FC<ChipProps> = ({
 
   const chipClasses = useMemo(
     () =>
-      [
-        styles.chipContainer,
-        styles.chip,
-        (leadingIcon || trailingIcon) && styles.chip_with_icon,
-        styles[variant || "ghost"],
-        styles[size || "medium"],
-        disabled ? styles.disabled : "",
-        interactive && !disabled ? `${styles.chip_with_button}` : "",
+      buildClassNames(
+        [
+          styles.chipContainer,
+          styles.chip,
+          styles[variant || "ghost"],
+          styles[size || "medium"],
+        ],
+        {
+          [styles.chip_with_icon]: !!(leadingIcon || trailingIcon),
+          [styles.chip_with_button]: !!(interactive && !disabled),
+          [styles.disabled]: !!disabled,
+        },
         className,
-      ].join(" "),
+      ),
     [
       className,
       disabled,
@@ -81,10 +86,10 @@ const Chip: React.FC<ChipProps> = ({
             variant={BUTTON_VARIANTS.PLAIN}
             size={BUTTON_SIZES.EXTRASMALL}
             icon={<Icon name="clear_icon" size={iconSize} />}
-            onClick={onClick}
+            onClick={onRemove}
             onMouseDown={(e) => e.preventDefault()}
             type="button"
-            aria-label="Clear input"
+            aria-label="delete chip"
             disabled={disabled}
           />
         </div>

--- a/src/components/Chip/Chip.types.ts
+++ b/src/components/Chip/Chip.types.ts
@@ -5,7 +5,7 @@ export interface ChipProps {
   className?: string;
   ariaLabel?: string;
   style?: React.CSSProperties;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onRemove?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   variant?: "solid" | "outline" | "ghost";
   children?: React.ReactNode;

--- a/src/components/Chip/__tests__/Chip.test.tsx
+++ b/src/components/Chip/__tests__/Chip.test.tsx
@@ -1,0 +1,370 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import Chip from "../Chip";
+import { CHIP_SIZES, CHIP_VARIANTS, CHIP_STATUSES } from "../Chip.types";
+import styles from "../styles.module.scss";
+import { ButtonProps } from "@components/Button";
+
+// Mock the Icon component since it's imported
+vi.mock("@components/Icon", () => ({
+  Icon: ({ name, size }: { name: string; size: number }) => (
+    <span data-testid={`icon-${name}`} data-size={size}>
+      {name}
+    </span>
+  ),
+}));
+
+// Mock the Button component
+vi.mock("@components/Button", () => ({
+  Button: ({
+    onClick,
+    children,
+    disabled,
+    icon,
+    onMouseDown,
+    "aria-label": ariaLabel,
+    ...props
+  }: ButtonProps) => (
+    <button
+      onClick={onClick}
+      onMouseDown={(e) => {
+        if (onMouseDown) {
+          onMouseDown(e);
+        }
+      }}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      data-testid="chip-remove-button"
+      {...props}
+    >
+      {icon}
+      {children}
+    </button>
+  ),
+  BUTTON_VARIANTS: {
+    PLAIN: "plain",
+  },
+  BUTTON_SIZES: {
+    EXTRASMALL: "xs",
+  },
+}));
+
+describe("Chip Component", () => {
+  const defaultProps = {
+    text: "Test Chip",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Basic Rendering", () => {
+    it("should render with default props", () => {
+      render(<Chip {...defaultProps} />);
+      expect(screen.getByText("Test Chip")).toBeInTheDocument();
+    });
+
+    it("should render with custom text", () => {
+      render(<Chip text="Custom Chip Text" />);
+      expect(screen.getByText("Custom Chip Text")).toBeInTheDocument();
+    });
+
+    it("should render children instead of text when provided", () => {
+      render(
+        <Chip text="Should not show">
+          <span>Custom Children</span>
+        </Chip>,
+      );
+      expect(screen.getByText("Custom Children")).toBeInTheDocument();
+      expect(screen.queryByText("Should not show")).not.toBeInTheDocument();
+    });
+
+    it("should apply custom className", () => {
+      const { container } = render(
+        <Chip {...defaultProps} className="custom-class" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("should apply custom styles", () => {
+      const customStyle = { backgroundColor: "red", color: "white" };
+      const { container } = render(
+        <Chip {...defaultProps} style={customStyle} />,
+      );
+      expect(container.firstChild).toHaveStyle(
+        "background-color: rgb(255, 0, 0)",
+      );
+      expect(container.firstChild).toHaveStyle("color: rgb(255, 255, 255)");
+    });
+  });
+
+  describe("Size Variants", () => {
+    it("should render with small size", () => {
+      const { container } = render(
+        <Chip {...defaultProps} size={CHIP_SIZES.SMALL} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.small);
+    });
+
+    it("should render with medium size (default)", () => {
+      const { container } = render(
+        <Chip {...defaultProps} size={CHIP_SIZES.MEDIUM} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.medium);
+    });
+
+    it("should render with large size", () => {
+      const { container } = render(
+        <Chip {...defaultProps} size={CHIP_SIZES.LARGE} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.large);
+    });
+
+    it("should default to medium size when no size provided", () => {
+      const { container } = render(<Chip {...defaultProps} />);
+      expect(container.firstChild).toHaveClass(styles.medium);
+    });
+  });
+
+  describe("Variants", () => {
+    it("should render with solid variant", () => {
+      const { container } = render(
+        <Chip {...defaultProps} variant={CHIP_VARIANTS.SOLID} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.solid);
+    });
+
+    it("should render with outline variant", () => {
+      const { container } = render(
+        <Chip {...defaultProps} variant={CHIP_VARIANTS.OUTLINE} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.outline);
+    });
+
+    it("should render with ghost variant (default)", () => {
+      const { container } = render(
+        <Chip {...defaultProps} variant={CHIP_VARIANTS.GHOST} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.ghost);
+    });
+
+    it("should default to ghost variant when no variant provided", () => {
+      const { container } = render(<Chip {...defaultProps} />);
+      expect(container.firstChild).toHaveClass(styles.ghost);
+    });
+  });
+
+  describe("Status", () => {
+    it("should render with info status", () => {
+      const { container } = render(
+        <Chip {...defaultProps} status={CHIP_STATUSES.INFO} />,
+      );
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).toBeInTheDocument();
+      expect(statusElement).toHaveClass(styles.info);
+    });
+
+    it("should render with success status", () => {
+      const { container } = render(
+        <Chip {...defaultProps} status={CHIP_STATUSES.SUCCESS} />,
+      );
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).toHaveClass(styles.success);
+    });
+
+    it("should render with warning status", () => {
+      const { container } = render(
+        <Chip {...defaultProps} status={CHIP_STATUSES.WARNING} />,
+      );
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).toHaveClass(styles.warning);
+    });
+
+    it("should render with error status", () => {
+      const { container } = render(
+        <Chip {...defaultProps} status={CHIP_STATUSES.ERROR} />,
+      );
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).toHaveClass(styles.error);
+    });
+
+    it("should render with custom status object", () => {
+      const customStatus = { class: "custom-status-class" };
+      const { container } = render(
+        <Chip {...defaultProps} status={customStatus} />,
+      );
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).toHaveClass("custom-status-class");
+    });
+
+    it("should not render status when not provided", () => {
+      const { container } = render(<Chip {...defaultProps} />);
+      const statusElement = container.querySelector(
+        `.${styles.statusContainer}`,
+      );
+      expect(statusElement).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Interactive Functionality", () => {
+    it("should render remove button when interactive is true", () => {
+      render(<Chip {...defaultProps} interactive={true} />);
+      expect(screen.getByTestId("chip-remove-button")).toBeInTheDocument();
+      expect(screen.getByTestId("icon-clear_icon")).toBeInTheDocument();
+    });
+
+    it("should not render remove button when interactive is false", () => {
+      render(<Chip {...defaultProps} interactive={false} />);
+      expect(
+        screen.queryByTestId("chip-remove-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not render remove button when disabled", () => {
+      render(<Chip {...defaultProps} interactive={true} disabled={true} />);
+      expect(
+        screen.queryByTestId("chip-remove-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should call onRemove when remove button is clicked", () => {
+      const onRemoveMock = vi.fn();
+      render(
+        <Chip {...defaultProps} interactive={true} onRemove={onRemoveMock} />,
+      );
+
+      fireEvent.click(screen.getByTestId("chip-remove-button"));
+      expect(onRemoveMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should have correct tabIndex when interactive", () => {
+      const { container } = render(
+        <Chip {...defaultProps} interactive={true} />,
+      );
+      expect(container.firstChild).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("should have tabIndex -1 when not interactive", () => {
+      const { container } = render(
+        <Chip {...defaultProps} interactive={false} />,
+      );
+      expect(container.firstChild).toHaveAttribute("tabIndex", "-1");
+    });
+  });
+
+  describe("Disabled State", () => {
+    it("should apply disabled class when disabled", () => {
+      const { container } = render(<Chip {...defaultProps} disabled={true} />);
+      expect(container.firstChild).toHaveClass(styles.disabled);
+    });
+
+    it("should set aria-disabled when disabled", () => {
+      const { container } = render(<Chip {...defaultProps} disabled={true} />);
+      expect(container.firstChild).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("should not render remove button when disabled and interactive", () => {
+      render(<Chip {...defaultProps} disabled={true} interactive={true} />);
+      expect(
+        screen.queryByTestId("chip-remove-button"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Icons", () => {
+    it("should render leading icon when provided", () => {
+      const leadingIcon = <span data-testid="leading-icon">Leading</span>;
+      render(<Chip {...defaultProps} leadingIcon={leadingIcon} />);
+      expect(screen.getByTestId("leading-icon")).toBeInTheDocument();
+    });
+
+    it("should render trailing icon when provided", () => {
+      const trailingIcon = <span data-testid="trailing-icon">Trailing</span>;
+      render(<Chip {...defaultProps} trailingIcon={trailingIcon} />);
+      expect(screen.getByTestId("trailing-icon")).toBeInTheDocument();
+    });
+
+    it("should apply icon classes when icons are present", () => {
+      const { container } = render(
+        <Chip {...defaultProps} leadingIcon={<span>Icon</span>} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.chip_with_icon);
+    });
+
+    it("should use correct icon size based on chip size", () => {
+      render(<Chip {...defaultProps} interactive={true} size="small" />);
+      expect(screen.getByTestId("icon-clear_icon")).toHaveAttribute(
+        "data-size",
+        "16",
+      );
+    });
+
+    it("should use medium icon size for medium chip", () => {
+      render(<Chip {...defaultProps} interactive={true} size="medium" />);
+      expect(screen.getByTestId("icon-clear_icon")).toHaveAttribute(
+        "data-size",
+        "20",
+      );
+    });
+
+    it("should use large icon size for large chip", () => {
+      render(<Chip {...defaultProps} interactive={true} size="large" />);
+      expect(screen.getByTestId("icon-clear_icon")).toHaveAttribute(
+        "data-size",
+        "24",
+      );
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should apply aria-label when provided", () => {
+      const { container } = render(
+        <Chip {...defaultProps} ariaLabel="Custom aria label" />,
+      );
+      expect(container.firstChild).toHaveAttribute(
+        "aria-label",
+        "Custom aria label",
+      );
+    });
+
+    it("should have proper aria-label on remove button", () => {
+      render(<Chip {...defaultProps} interactive={true} />);
+      expect(screen.getByTestId("chip-remove-button")).toHaveAttribute(
+        "aria-label",
+        "delete chip",
+      );
+    });
+  });
+
+  describe("CSS Classes", () => {
+    it("should apply interactive classes when interactive and not disabled", () => {
+      const { container } = render(
+        <Chip {...defaultProps} interactive={true} disabled={false} />,
+      );
+      expect(container.firstChild).toHaveClass(styles.chip_with_button);
+    });
+
+    it("should not apply interactive classes when disabled", () => {
+      const { container } = render(
+        <Chip {...defaultProps} interactive={true} disabled={true} />,
+      );
+      expect(container.firstChild).not.toHaveClass("chip_with_button");
+    });
+
+    it("should always include base classes", () => {
+      const { container } = render(<Chip {...defaultProps} />);
+      expect(container.firstChild).toHaveClass(styles.chipContainer);
+      expect(container.firstChild).toHaveClass(styles.chip);
+    });
+  });
+});

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -9,6 +9,7 @@ import React, {
 import type { MultiSelectProps, MultiSelectOption } from "./MultiSelect.types";
 import { iconSvgMapping } from "@assets";
 import styles from "./styles.module.scss";
+import { Chip } from "@components/Chip";
 
 const ClearIcon = iconSvgMapping["clear_icon"];
 
@@ -239,20 +240,18 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
       </div>
       <div className={styles.tagContainer}>
         {selectedOptions.map((opt) => (
-          <span key={opt.value} className={styles.tag}>
-            {opt.label}
-            <button
-              type="button"
-              className={styles.tagRemoveBtn}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleRemove(opt.value);
-              }}
-              aria-label={`Remove tag ${opt.label}`}
-            >
-              <ClearIcon className={styles.clearIcon} />
-            </button>
-          </span>
+          <Chip
+            key={opt.value}
+            text={opt.label}
+            interactive={true}
+            onRemove={(e) => {
+              e.stopPropagation();
+              handleRemove(opt.value);
+            }}
+            size="small"
+            variant="outline"
+            disabled={disabled}
+          />
         ))}
       </div>
     </>

--- a/src/utils/__tests__/classNames.test.ts
+++ b/src/utils/__tests__/classNames.test.ts
@@ -1,0 +1,144 @@
+import { buildClassNames, combineClasses } from "../classNames";
+
+describe("buildClassNames", () => {
+  it("should combine base classes with conditional classes", () => {
+    const result = buildClassNames(["base", "component"], {
+      active: true,
+      disabled: false,
+      large: true,
+    });
+    expect(result).toBe("base component active large");
+  });
+
+  it("should handle empty base classes", () => {
+    const result = buildClassNames([], {
+      active: true,
+      disabled: false,
+    });
+    expect(result).toBe("active");
+  });
+
+  it("should handle empty conditional classes", () => {
+    const result = buildClassNames(["base", "component"], {});
+    expect(result).toBe("base component");
+  });
+
+  it("should include custom className when provided", () => {
+    const result = buildClassNames(["base"], { active: true }, "custom-class");
+    expect(result).toBe("base active custom-class");
+  });
+
+  it("should ignore custom className when undefined", () => {
+    const result = buildClassNames(["base"], { active: true }, undefined);
+    expect(result).toBe("base active");
+  });
+
+  it("should handle all false conditions", () => {
+    const result = buildClassNames(["base"], {
+      active: false,
+      disabled: false,
+      large: false,
+    });
+    expect(result).toBe("base");
+  });
+
+  it("should handle all true conditions", () => {
+    const result = buildClassNames(["base"], {
+      active: true,
+      disabled: true,
+      large: true,
+    });
+    expect(result).toBe("base active disabled large");
+  });
+
+  it("should filter out falsy base classes", () => {
+    const result = buildClassNames(["base", "", "component"], { active: true });
+    expect(result).toBe("base component active");
+  });
+
+  it("should work with complex class names", () => {
+    const result = buildClassNames(
+      ["btn", "btn-primary"],
+      {
+        "btn--large": true,
+        "btn--disabled": false,
+        btn_with_icon: true,
+      },
+      "my-custom-btn",
+    );
+    expect(result).toBe(
+      "btn btn-primary btn--large btn_with_icon my-custom-btn",
+    );
+  });
+});
+
+describe("combineClasses", () => {
+  it("should combine string classes", () => {
+    const result = combineClasses("class1", "class2", "class3");
+    expect(result).toBe("class1 class2 class3");
+  });
+
+  it("should filter out falsy values", () => {
+    const isEmpty = false;
+    const isActive = false;
+    const result = combineClasses(
+      "class1",
+      isActive && "class2",
+      null,
+      undefined,
+      "class3",
+      isEmpty && "class4",
+    );
+    expect(result).toBe("class1 class3");
+  });
+
+  it("should handle conditional classes with logical operators", () => {
+    const isActive = true;
+    const isDisabled = false;
+    const customClass = "custom";
+
+    const result = combineClasses(
+      "base",
+      isActive && "active",
+      isDisabled && "disabled",
+      customClass,
+    );
+    expect(result).toBe("base active custom");
+  });
+
+  it("should handle empty input", () => {
+    const result = combineClasses();
+    expect(result).toBe("");
+  });
+
+  it("should handle all falsy values", () => {
+    const result = combineClasses(false, null, undefined, "");
+    expect(result).toBe("");
+  });
+
+  it("should handle mixed types correctly", () => {
+    const isActive = true;
+    const isDisabled = false;
+    const result = combineClasses(
+      "base",
+      isActive && "active",
+      isDisabled && "disabled",
+      null,
+      undefined,
+      "final",
+    );
+    expect(result).toBe("base active final");
+  });
+
+  it("should work with ternary operators", () => {
+    const variant = "primary";
+    const size = "large";
+
+    const result = combineClasses(
+      "btn",
+      variant === "primary" ? "btn-primary" : "btn-secondary",
+      size === "large" ? "btn-lg" : "btn-sm",
+    );
+    expect(result).toBe("btn btn-primary btn-lg");
+  });
+});

--- a/src/utils/classNames.ts
+++ b/src/utils/classNames.ts
@@ -1,0 +1,58 @@
+/**
+ * Utility function for building CSS class names with conditional logic
+ *
+ * @param baseClasses - Array of base CSS classes that are always applied
+ * @param conditionalClasses - Object with class names as keys and boolean conditions as values
+ * @param customClassName - Optional custom class name to append
+ * @returns Combined class string with all applicable classes
+ *
+ * @example
+ * ```tsx
+ * const classes = buildClassNames(
+ *   ['base-class', 'component'],
+ *   {
+ *     'active': isActive,
+ *     'disabled': isDisabled,
+ *     'large': size === 'large'
+ *   },
+ *   customClassName
+ * );
+ * ```
+ */
+export const buildClassNames = (
+  baseClasses: string[],
+  conditionalClasses: Record<string, boolean>,
+  customClassName?: string,
+): string => {
+  return [
+    ...baseClasses,
+    ...Object.entries(conditionalClasses)
+      .filter(([, condition]) => condition)
+      .map(([className]) => className),
+    customClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+};
+
+/**
+ * Simple utility to combine class names, filtering out falsy values
+ *
+ * @param classes - Array of class names (can include falsy values)
+ * @returns Combined class string
+ *
+ * @example
+ * ```tsx
+ * const classes = combineClasses([
+ *   'base-class',
+ *   isActive && 'active',
+ *   isDisabled && 'disabled',
+ *   customClassName
+ * ]);
+ * ```
+ */
+export const combineClasses = (
+  ...classes: (string | boolean | null | undefined)[]
+): string => {
+  return classes.filter(Boolean).join(" ");
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./classNames";

--- a/stories/Chip.stories.tsx
+++ b/stories/Chip.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
   },
   tags: ["autodocs"],
   args: {
-    onClick: fn(),
+    onRemove: fn(),
     variant: CHIP_VARIANTS.OUTLINE,
     size: CHIP_SIZES.MEDIUM,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       "@assets": path.resolve(dirname, "src/assets"),
       "@styles": path.resolve(dirname, "src/styles"),
       "@types": path.resolve(dirname, "src/types"),
+      "@utils": path.resolve(dirname, "src/utils"),
     },
   },
 });


### PR DESCRIPTION
## Pull Request Overview

This PR refactors style class name construction by moving the logic to a utility function and adds comprehensive unit tests. The changes improve code maintainability by centralizing class name building logic and replacing manual string concatenation with a more robust utility approach.

- Adds utility functions for building CSS class names with conditional logic
- Refactors Chip component to use the new utility functions instead of manual class concatenation
- Updates component props from `onClick` to `onRemove` for better semantic clarity
- Adds comprehensive test coverage for both the utility functions and Chip component